### PR TITLE
Use JXL format in mogrify

### DIFF
--- a/scripts/optimizeImage.sh
+++ b/scripts/optimizeImage.sh
@@ -5,7 +5,7 @@ OUTPUT="$2"
 
 cp "$INPUT" "$OUTPUT" || exit 1
 
-mogrify -format jpg "$OUTPUT" || exit 2
+mogrify -format jxl "$OUTPUT" || exit 2
 mogrify -resize 3840x2160^ "$OUTPUT" || exit 3
 
 QUALITY=$(identify -format %Q  $OUTPUT) 


### PR DESCRIPTION
## Description

Use JXL format for mogrify in `optimizeImage.sh`.

### Submitter Checklist

- [x] Submitter has reviewed the Image Requirements
- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Updated the respective `meson.build` and `xml.in` files
